### PR TITLE
Altered special key coloring to be more discreet.

### DIFF
--- a/colors/seti.vim
+++ b/colors/seti.vim
@@ -50,7 +50,7 @@ hi Number                       ctermfg=167   ctermbg=NONE  cterm=NONE          
 hi Operator                     ctermfg=149   ctermbg=NONE  cterm=NONE          guifg=#9fca56   guibg=NONE      gui=NONE
 hi PreProc                      ctermfg=197   ctermbg=NONE  cterm=NONE          guifg=#ff026a   guibg=NONE      gui=NONE
 hi Special                      ctermfg=188   ctermbg=NONE  cterm=NONE          guifg=#d4d7d6   guibg=NONE      gui=NONE
-hi SpecialKey                   ctermfg=73    ctermbg=235   cterm=NONE          guifg=#abaee8   guibg=#282a2b   gui=NONE
+hi SpecialKey                   ctermfg=73    ctermbg=NONE  cterm=NONE          guifg=#4a4a4a   guibg=NONE   	gui=NONE
 hi Statement                    ctermfg=149   ctermbg=NONE  cterm=NONE          guifg=#9fca56   guibg=NONE      gui=NONE
 hi StorageClass                 ctermfg=185   ctermbg=NONE  cterm=NONE          guifg=#e6cd69   guibg=NONE      gui=NONE
 hi String                       ctermfg=74    ctermbg=NONE  cterm=NONE          guifg=#55b5db   guibg=NONE      gui=NONE


### PR DESCRIPTION
It seems that the problem of the light colouring had something to do with how special keys were coloured (i.e. tabs). This commit removes the light background and makes the foreground color of the GUI text more discreet as not to get confused with actual text in the file.
